### PR TITLE
Fix deprecation warning for ActiveRecord.

### DIFF
--- a/app/app/models/game_result.rb
+++ b/app/app/models/game_result.rb
@@ -7,7 +7,7 @@ class GameResult < ApplicationRecord
 
   belongs_to :game_schedule
 
-  enum result: { home_win: 'home_win', visitor_win: 'visitor_win', draw: 'draw', canceled: 'canceled' }
+  enum :result, { home_win: 'home_win', visitor_win: 'visitor_win', draw: 'draw', canceled: 'canceled' }
 
   validates :game_schedule, uniqueness: true
   validates :home_team_score, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }


### PR DESCRIPTION
fix: https://github.com/yamat47/kcff-match-hub/issues/64

Fixed warning is here:

> DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
> in Rails 8.0. Positional arguments should be used instead:
> enum :result, {:home_win=>"home_win", :visitor_win=>"visitor_win", :draw=>"draw", :canceled=>"canceled"}
>  (called from <class:GameResult> at /home/runner/work/kcff-match-hub/kcff-match-hub/app/app/models/game_result.rb:10)