### PR TITLE
Disable turbo cache.

### DIFF
--- a/app/app/views/layouts/media/application.html.haml
+++ b/app/app/views/layouts/media/application.html.haml
@@ -10,6 +10,7 @@
     = stylesheet_link_tag 'media', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
     %meta{ name: 'turbo-prefetch', content: 'true' }
+    %meta{ name: 'turbo-cache-control', content: 'no-cache' }
     %meta{ name: 'view-transition', content: 'same-origin' }
     %link{ rel: 'icon', href: '/favicon.ico', sizes: '32x32' }
     %link{ rel: 'icon', href: '/icon.svg', type: 'image/svg+xml' }


### PR DESCRIPTION
Using cache, hero image transition's timing is ticky.